### PR TITLE
Epsilon constraint enforcement

### DIFF
--- a/ares/attacker/attack.py
+++ b/ares/attacker/attack.py
@@ -9,10 +9,11 @@ from ares.defender import Classifier
 
 
 class Attack:
-    def __init__(self, type: str, name: str, params: dict):
+    def __init__(self, type: str, name: str, params: dict, epsilon_constraint: bool = True):
         self.type = type
         self.name = name
         self.params = params
+        self.epsilon_constraint = epsilon_constraint
         self.norm = params.get("norm", "inf")
         self.eps = params.get("eps", 8 / 255)
 
@@ -26,15 +27,15 @@ class Attack:
 
         if self.norm == "inf":
             eps = np.linalg.norm(np.abs(x_adv - x).ravel(), ord=np.inf)
-        elif self.norm == "l1":
+        elif self.norm in (1, "1", "l1"):
             eps = np.linalg.norm(np.abs(x_adv - x).ravel(), ord=1)
-        elif self.norm == "l2":
+        elif self.norm in (2, "2", "l2"):
             eps = np.linalg.norm(np.abs(x_adv - x).ravel(), ord=2)
         else:
             raise ValueError(f"Error generating attack: {self.norm} norm not supported")
 
         # Enforce epsilon constraint
-        if eps > self.eps:
+        if self.epsilon_constraint and eps > self.eps:
             raise ValueError("Error generating attack: epsilon constraint violated")
 
         return x_adv, eps

--- a/ares/attacker/attacker_agent.py
+++ b/ares/attacker/attacker_agent.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from art.estimators.classification import PyTorchClassifier
 from gym import spaces
@@ -28,13 +28,13 @@ class AttackerAgent:
             return p < self.evasion_probability
         return False
 
-    def attack(self, classifier: PyTorchClassifier, x: np.ndarray, y: np.ndarray) -> Optional[np.ndarray]:
+    def attack(self, classifier: PyTorchClassifier, x: np.ndarray, y: np.ndarray) -> Tuple[np.ndarray, float, bool]:
         evade_turn = self.evade()
         if evade_turn:
-            return None
+            return x, 0, True
 
         self.index = np.random.choice(len(self.attacks), p=self.probabilities)
         self.active_attack = self.attacks[self.index]
-        x_adv = self.active_attack.generate(classifier, x, y)
+        x_adv, eps = self.active_attack.generate(classifier, x, y)
         self.num_steps += 1
-        return x_adv
+        return x_adv, eps, False

--- a/ares/attacker/attacker_agent.py
+++ b/ares/attacker/attacker_agent.py
@@ -22,7 +22,7 @@ class AttackerAgent:
     def update_policy(self, observation: dict):
         pass
 
-    def evade(self):
+    def evade(self) -> bool:
         if self.evasion_probability is not None:
             p = np.random.rand()
             return p < self.evasion_probability

--- a/ares/environment/ares_environment.py
+++ b/ares/environment/ares_environment.py
@@ -49,12 +49,12 @@ class AresEnvironment(gym.Env):
 
         # attacker turn
         self.attacker.update_policy({})
-        x_adv = self.attacker.attack(classifier, x, y)
+        x_adv, eps, evaded = self.attacker.attack(classifier, x, y)
 
         # run detector if not evading
-        if x_adv is None:
-            x_adv = x
+        if evaded:
             detected = False
+            x_adv = x
         else:
             detected = self.defender.detect(x_adv)
 
@@ -76,6 +76,9 @@ class AresEnvironment(gym.Env):
             "y": y,
             "x_adv": x_adv,
             "y_pred": y_pred,
+            "eps": eps,
+            "evaded": evaded,
+            "detected": detected,
             "winner": winner,
         }
         info = {

--- a/ares/run.py
+++ b/ares/run.py
@@ -38,10 +38,18 @@ def run_simulation(args):
             observation, reward, done, info = env.step(action)
             x = observation["x_adv"]
             y_pred = observation["y_pred"]
+            eps = observation["eps"]
+            evaded = observation["evaded"]
+            detected = observation["detected"]
             winner = observation["winner"]
             step_count = info["step_count"]
 
-            print(f"Step {step_count:2}: ({y[0]} | {y_pred[0]})")
+            if evaded:
+                print(f"Step {step_count:2}: ({y[0]} | {y_pred[0]}), eps = {eps:.6f}, attacker evaded")
+            elif detected:
+                print(f"Step {step_count:2}: ({y[0]} | {y_pred[0]}), eps = {eps:.6f}, attacker was detected")
+            else:
+                print(f"Step {step_count:2}: ({y[0]} | {y_pred[0]}), eps = {eps:.6f}")
 
         print(f"Game end: {winner} wins after {reward} rounds")
         episode_rewards.append(reward)

--- a/ares/utils.py
+++ b/ares/utils.py
@@ -22,8 +22,9 @@ def get_attacker_agent(config: dict) -> AttackerAgent:
     for attack_config in attacker_attacks:
         attack_type = attack_config["type"]
         attack_name = attack_config["name"]
-        attack_params = attack_config["params"]
-        attack = Attack(attack_type, attack_name, attack_params)
+        attack_params = attack_config.get("params", {})
+        epsilon_constraint = attack_config.get("epsilon_constraint", True)
+        attack = Attack(attack_type, attack_name, attack_params, epsilon_constraint)
         attacks.append(attack)
 
     probabilities = config["attacker"].get("probabilities", None)
@@ -45,7 +46,7 @@ def get_defender_agent(config: dict) -> DefenderAgent:
     for model_config in defender_models:
         model_file = model_config["file"]
         model_name = model_config["name"]
-        model_params = model_config["params"]
+        model_params = model_config.get("params", {})
         model_checkpoint = model_config["checkpoint"]
         classifier = Classifier(
             file=model_file,

--- a/configs/blackbox.json
+++ b/configs/blackbox.json
@@ -12,7 +12,8 @@
                     "targeted": false,
                     "batch_size": 1,
                     "verbose": false
-                }
+                },
+                "epsilon_constraint": false
             }
         ]
     },


### PR DESCRIPTION
fixes #23 

Calculates epsilon perturbation for each attack iteration and enforces the epsilon constraint. Will infer the epsilon and norm based on the specified parameters for the attack and default to 8 / 255, L-inf norm. Throws error if violated.

This can be turned off by specifying `"epsilon_constraint": false` in the JSON config for the attack.